### PR TITLE
Replace use of `http.client.OK` et al with `http.HTTPStatus`

### DIFF
--- a/invenio_sword/views.py
+++ b/invenio_sword/views.py
@@ -1,7 +1,7 @@
-import http.client
 import typing
 from copy import deepcopy
 from functools import partial
+from http import HTTPStatus
 
 from flask import Blueprint
 from flask import current_app
@@ -185,7 +185,7 @@ class ServiceDocumentView(SWORDDepositView):
         self.update_deposit(record)
 
         response = self.make_response(record.get_status_as_jsonld())  # type: Response
-        response.status_code = http.client.CREATED
+        response.status_code = HTTPStatus.CREATED
         response.headers["Location"] = record.sword_status_url
         return response
 
@@ -233,7 +233,7 @@ class DepositMetadataView(SWORDDepositView):
         self.set_metadata(record, request.stream, replace=False)
         record.commit()
         db.session.commit()
-        return Response(status=http.client.NO_CONTENT)
+        return Response(status=HTTPStatus.NO_CONTENT)
 
     @pass_record
     @need_record_permission("update_permission_factory")
@@ -241,7 +241,7 @@ class DepositMetadataView(SWORDDepositView):
         self.set_metadata(record, request.stream)
         record.commit()
         db.session.commit()
-        return Response(status=http.client.NO_CONTENT)
+        return Response(status=HTTPStatus.NO_CONTENT)
 
     @pass_record
     @need_record_permission("delete_permission_factory")
@@ -249,7 +249,7 @@ class DepositMetadataView(SWORDDepositView):
         record.sword_metadata = None
         record.commit()
         db.session.commit()
-        return Response(status=http.client.NO_CONTENT)
+        return Response(status=HTTPStatus.NO_CONTENT)
 
 
 class DepositFilesetView(SWORDDepositView):
@@ -265,7 +265,7 @@ class DepositFilesetView(SWORDDepositView):
             else None,
             replace=False,
         )
-        return Response(status=http.client.NO_CONTENT)
+        return Response(status=HTTPStatus.NO_CONTENT)
 
     @pass_record
     @need_record_permission("update_permission_factory")
@@ -276,7 +276,7 @@ class DepositFilesetView(SWORDDepositView):
             if (request.content_type or request.content_length)
             else None,
         )
-        return Response(status=http.client.NO_CONTENT)
+        return Response(status=HTTPStatus.NO_CONTENT)
 
 
 def create_blueprint(endpoints):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,8 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 """Test the API."""
-import http.client
 import re
+from http import HTTPStatus
 
 from flask_security import url_for_security
 from invenio_files_rest.models import ObjectVersion
@@ -34,7 +34,7 @@ from invenio_sword.api import pid_resolver
 def test_get_service_document(api):
     with api.test_client() as client:
         response = client.get("/sword/service-document")
-        assert response.status_code == 200
+        assert response.status_code == HTTPStatus.OK
         assert response.is_json
 
 
@@ -46,7 +46,7 @@ def test_deposit_empty(api, users, location):
         )
 
         response = client.post("/sword/service-document")
-        assert response.status_code == http.client.CREATED
+        assert response.status_code == HTTPStatus.CREATED
         match = re.match(
             "^http://localhost/sword/deposit/([^/]+)$", response.headers["Location"]
         )
@@ -85,7 +85,7 @@ def test_metadata_deposit(api, users, location, metadata_document):
                 "Content-Type": "application/ld+json",
             },
         )
-        assert response.status_code == http.client.CREATED
+        assert response.status_code == HTTPStatus.CREATED
         match = re.match(
             "^http://localhost/sword/deposit/([^/]+)$", response.headers["Location"]
         )

--- a/tests/test_bagit.py
+++ b/tests/test_bagit.py
@@ -22,8 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 """Test the BagIt implementation."""
-import http.client
 import os
+from http import HTTPStatus
 
 import pytest
 from flask import url_for
@@ -52,7 +52,7 @@ def test_post_service_document_with_bagit_bag(api, users, location):
                 },
             )
 
-        assert response.status_code == http.client.CREATED
+        assert response.status_code == HTTPStatus.CREATED
 
         bucket = Bucket.query.one()
         obj_1 = ObjectVersion.query.filter_by(bucket=bucket, key="example.svg").one()
@@ -94,9 +94,9 @@ def test_post_service_document_with_bagit_bag(api, users, location):
 @pytest.mark.parametrize(
     "filename,status_code",
     [
-        ("bagit-broken-sha.zip", http.client.BAD_REQUEST),
-        ("bagit-no-bagit-txt.zip", http.client.BAD_REQUEST),
-        ("bagit-with-fetch.zip", http.client.NOT_IMPLEMENTED),
+        ("bagit-broken-sha.zip", HTTPStatus.BAD_REQUEST),
+        ("bagit-no-bagit-txt.zip", HTTPStatus.BAD_REQUEST),
+        ("bagit-with-fetch.zip", HTTPStatus.NOT_IMPLEMENTED),
     ],
 )
 def test_post_service_document_with_broken_bag(
@@ -138,4 +138,4 @@ def test_post_service_document_with_incorrect_content_type(api, users, location)
                 },
             )
 
-        assert response.status_code == http.client.UNSUPPORTED_MEDIA_TYPE
+        assert response.status_code == HTTPStatus.UNSUPPORTED_MEDIA_TYPE

--- a/tests/test_fileset_view.py
+++ b/tests/test_fileset_view.py
@@ -1,6 +1,6 @@
-import http.client
 import io
 import time
+from http import HTTPStatus
 
 from flask import url_for
 from flask_security import url_for_security
@@ -27,7 +27,7 @@ def test_get_fileset_url(api, users, location, es):
                 "invenio_sword.depid_deposit_fileset", pid_value=record.pid.pid_value
             )
         )
-        assert response.status_code == http.client.METHOD_NOT_ALLOWED
+        assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED
 
 
 def test_put_fileset_url(api, users, location, es):
@@ -58,7 +58,7 @@ def test_put_fileset_url(api, users, location, es):
                 "Content-Type": "text/plain",
             },
         )
-        assert response.status_code == http.client.NO_CONTENT
+        assert response.status_code == HTTPStatus.NO_CONTENT
 
         # Check original ObjectVersion is marked deleted
         original_object_versions = list(
@@ -106,7 +106,7 @@ def test_post_fileset_url(api, users, location, es):
                 "Content-Type": "text/plain",
             },
         )
-        assert response.status_code == http.client.NO_CONTENT
+        assert response.status_code == HTTPStatus.NO_CONTENT
 
         # Check original ObjectVersion is still there
         original_object_versions = list(

--- a/tests/test_metadata_view.py
+++ b/tests/test_metadata_view.py
@@ -1,7 +1,7 @@
-import http.client
 import io
 import json
 import time
+from http import HTTPStatus
 
 import pytest
 from flask import url_for
@@ -26,10 +26,10 @@ def test_get_metadata_document(api, users, location, es):
         time.sleep(1)
 
         response = client.get("/sword/deposit/{}".format(record.pid.pid_value))
-        assert response.status_code == 200
+        assert response.status_code == HTTPStatus.OK
 
         response = client.get("/sword/deposit/{}/metadata".format(record.pid.pid_value))
-        assert response.status_code == 200
+        assert response.status_code == HTTPStatus.OK
         assert response.is_json
         assert (
             response.headers["Metadata-Format"]
@@ -55,11 +55,11 @@ def test_get_metadata_document_when_not_available(api, users, location, es):
         time.sleep(1)
 
         status_response = client.get("/sword/deposit/{}".format(record.pid.pid_value))
-        assert status_response.status_code == http.client.OK
+        assert status_response.status_code == HTTPStatus.OK
         status_response = client.get(
             "/sword/deposit/{}/metadata".format(record.pid.pid_value)
         )
-        assert status_response.status_code == http.client.NOT_FOUND
+        assert status_response.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_put_metadata_document_without_body(api, users, location, es):
@@ -74,7 +74,7 @@ def test_put_metadata_document_without_body(api, users, location, es):
         time.sleep(1)
 
         response = client.put("/sword/deposit/{}/metadata".format(record.pid.pid_value))
-        assert response.status_code == http.client.UNSUPPORTED_MEDIA_TYPE
+        assert response.status_code == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
 
 def test_put_metadata_document_invalid_json(api, users, location, es):
@@ -95,7 +95,7 @@ def test_put_metadata_document_invalid_json(api, users, location, es):
                 "Metadata-Format": "http://purl.org/net/sword/3.0/types/Metadata",
             },
         )
-        assert response.status_code == http.client.BAD_REQUEST
+        assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_put_metadata_document(api, users, location, es):
@@ -117,7 +117,7 @@ def test_put_metadata_document(api, users, location, es):
             },
             data=json.dumps({}),
         )
-        assert response.status_code == http.client.NO_CONTENT
+        assert response.status_code == HTTPStatus.NO_CONTENT
 
         record = SWORDDeposit.get_record(record.id)
         assert (
@@ -131,10 +131,10 @@ def test_put_metadata_document(api, users, location, es):
 @pytest.mark.parametrize(
     "view_name,status_code,additional_headers",
     [
-        ("invenio_sword.depid_deposit_metadata", http.client.NO_CONTENT, {}),
+        ("invenio_sword.depid_deposit_metadata", HTTPStatus.NO_CONTENT, {}),
         (
             "invenio_sword.depid_deposit_status",
-            http.client.OK,
+            HTTPStatus.OK,
             {"Content-Disposition": "attachment; metadata=true"},
         ),
     ],
@@ -218,7 +218,7 @@ def test_post_metadata_document_with_inconsistent_metadata_format(
             },
             data=io.BytesIO(b"some metadata"),
         )
-        assert response.status_code == http.client.CONFLICT
+        assert response.status_code == HTTPStatus.CONFLICT
 
         record = SWORDDeposit.get_record(record.id)
         assert (
@@ -253,7 +253,7 @@ def test_put_metadata_document_with_unsupported_format(api, users, location, es)
             },
             data=json.dumps({}),
         )
-        assert response.status_code == http.client.NOT_IMPLEMENTED
+        assert response.status_code == HTTPStatus.NOT_IMPLEMENTED
 
 
 def test_delete_metadata_document(api, users, location, es):
@@ -274,7 +274,7 @@ def test_delete_metadata_document(api, users, location, es):
         response = client.delete(
             "/sword/deposit/{}/metadata".format(record.pid.pid_value)
         )
-        assert response.status_code == http.client.NO_CONTENT
+        assert response.status_code == HTTPStatus.NO_CONTENT
 
         record = SWORDDeposit.get_record(record.id)
         assert record.sword_metadata_format is None

--- a/tests/test_status_view.py
+++ b/tests/test_status_view.py
@@ -1,6 +1,6 @@
-import http.client
 import io
 import time
+from http import HTTPStatus
 
 from flask_security import url_for_security
 from invenio_db import db
@@ -12,7 +12,7 @@ from invenio_sword.api import SWORDDeposit
 def test_get_status_document_not_found(api, location, es):
     with api.app_context(), api.test_client() as client:
         response = client.get("/sword/deposit/1234")
-        assert response.status_code == http.client.NOT_FOUND
+        assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_get_status_document(api, users, location, es):
@@ -34,7 +34,7 @@ def test_get_status_document(api, users, location, es):
         )
 
         response = client.get("/sword/deposit/{}".format(record.pid.pid_value))
-        assert response.status_code == http.client.OK
+        assert response.status_code == HTTPStatus.OK
         assert len(response.json["links"]) == 1
         assert response.json["links"][0]["contentType"] == "text/n3"
 
@@ -60,7 +60,7 @@ def test_put_status_document(api, users, location, es):
         response = client.put(
             "/sword/deposit/{}".format(record.pid.pid_value), data=b""
         )
-        assert response.status_code == http.client.OK
+        assert response.status_code == HTTPStatus.OK
 
         # This should have removed the previous file, as the empty PUT is a reset.
         object_versions = list(

--- a/tests/test_zip_packaging.py
+++ b/tests/test_zip_packaging.py
@@ -22,8 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 """Test the BagIt implementation."""
-import http.client
 import os
+from http import HTTPStatus
 
 from flask import url_for
 from flask_security import url_for_security
@@ -50,7 +50,7 @@ def test_post_service_document_with_simple_zip(api, users, location):
                 },
             )
 
-        assert response.status_code == http.client.CREATED
+        assert response.status_code == HTTPStatus.CREATED
 
         bucket = Bucket.query.one()
         obj_1 = ObjectVersion.query.filter_by(bucket=bucket, key="example.svg").one()


### PR DESCRIPTION
The previous way was deprecated, and broke code introspection in PyCharm. This is much tidier.