### PR TITLE
Upload original deposits, and use ObjectVersionTags to keep track of files

### DIFF
--- a/invenio_sword/enum.py
+++ b/invenio_sword/enum.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class ObjectTagKey(enum.Enum):
+    OriginalDeposit = "invenio_sword.originalDeposit"
+    DerivedFrom = "invenio_sword.derivedFrom"
+    FileSetFile = "invenio_sword.fileSetFile"
+    Packaging = "invenio_sword.packaging"

--- a/invenio_sword/packaging/bagit.py
+++ b/invenio_sword/packaging/bagit.py
@@ -2,16 +2,19 @@ import mimetypes
 import os
 import shutil
 import tempfile
+import uuid
 import zipfile
 
 import bagit
 from invenio_files_rest.models import ObjectVersion
+from invenio_files_rest.models import ObjectVersionTag
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import NotImplemented
 from werkzeug.exceptions import UnsupportedMediaType
 
 from .base import Packaging
 from invenio_sword.api import SWORDDeposit
+from invenio_sword.enum import ObjectTagKey
 from invenio_sword.metadata import SWORDMetadata
 from invenio_sword.typing import BytesReader
 
@@ -20,6 +23,7 @@ __all__ = ["SWORDBagItPackaging"]
 
 class SWORDBagItPackaging(Packaging):
     content_type = "application/zip"
+    packaging_name = "http://purl.org/net/sword/3.0/package/SWORDBagIt"
 
     def ingest(
         self,
@@ -32,6 +36,8 @@ class SWORDBagItPackaging(Packaging):
         if content_type != self.content_type:
             raise UnsupportedMediaType
 
+        original_deposit_filename = "original-deposit-{}.zip".format(uuid.uuid4())
+
         with tempfile.TemporaryDirectory() as path:
             try:
                 with tempfile.TemporaryFile() as f:
@@ -40,6 +46,24 @@ class SWORDBagItPackaging(Packaging):
                     zip = zipfile.ZipFile(f)
                     zip.extractall(path)
                     zip.close()
+                    f.seek(0)
+
+                    original_deposit = ObjectVersion.create(
+                        record.bucket,
+                        original_deposit_filename,
+                        mimetype=self.content_type,
+                        stream=f,
+                    )
+                    ObjectVersionTag.create(
+                        object_version=original_deposit,
+                        key=ObjectTagKey.OriginalDeposit.value,
+                        value="true",
+                    )
+                    ObjectVersionTag.create(
+                        object_version=original_deposit,
+                        key=ObjectTagKey.Packaging.value,
+                        value=self.packaging_name,
+                    )
 
                 bag = bagit.Bag(path)
                 bag.validate()
@@ -65,15 +89,25 @@ class SWORDBagItPackaging(Packaging):
                 # Ingest payload files
                 for name in bag.payload_entries():
                     with open(os.path.join(path, name), "rb") as payload_f:
-                        ObjectVersion.create(
+                        object_version = ObjectVersion.create(
                             record.bucket,
                             name.split(os.path.sep, 1)[-1],
                             mimetype=mimetypes.guess_type(name)[0],
                             stream=payload_f,
                         )
+                        ObjectVersionTag.create(
+                            object_version=object_version,
+                            key=ObjectTagKey.FileSetFile.value,
+                            value="true",
+                        )
+                        ObjectVersionTag.create(
+                            object_version=object_version,
+                            key=ObjectTagKey.DerivedFrom.value,
+                            value=original_deposit_filename,
+                        )
                 return {
                     name.split(os.path.sep, 1)[-1] for name in bag.payload_entries()
-                }
+                } | {original_deposit_filename}
             except bagit.BagValidationError as e:
                 raise BadRequest(e.message) from e
             except bagit.BagError as e:

--- a/invenio_sword/packaging/base.py
+++ b/invenio_sword/packaging/base.py
@@ -3,6 +3,8 @@ from invenio_sword.typing import BytesReader
 
 
 class Packaging:
+    packaging_name: str
+
     def ingest(
         self,
         *,

--- a/invenio_sword/packaging/binary.py
+++ b/invenio_sword/packaging/binary.py
@@ -1,15 +1,19 @@
 import mimetypes
 
 from invenio_files_rest.models import ObjectVersion
+from invenio_files_rest.models import ObjectVersionTag
 
 from ..api import SWORDDeposit
 from .base import Packaging
+from invenio_sword.enum import ObjectTagKey
 from invenio_sword.typing import BytesReader
 
 __all__ = ["BinaryPackaging"]
 
 
 class BinaryPackaging(Packaging):
+    packaging_name = "http://purl.org/net/sword/3.0/package/Binary"
+
     def ingest(
         self,
         *,
@@ -25,8 +29,19 @@ class BinaryPackaging(Packaging):
             else:
                 filename = "data"
 
-        ObjectVersion.create(
+        object_version = ObjectVersion.create(
             record.bucket, filename, mimetype=content_type, stream=stream
+        )
+
+        ObjectVersionTag.create(
+            object_version=object_version,
+            key=ObjectTagKey.OriginalDeposit.value,
+            value="true",
+        )
+        ObjectVersionTag.create(
+            object_version=object_version,
+            key=ObjectTagKey.FileSetFile.value,
+            value="true",
         )
 
         return {filename}

--- a/invenio_sword/packaging/zip.py
+++ b/invenio_sword/packaging/zip.py
@@ -1,13 +1,16 @@
 import mimetypes
 import shutil
 import tempfile
+import uuid
 import zipfile
 
 from invenio_files_rest.models import ObjectVersion
+from invenio_files_rest.models import ObjectVersionTag
 from werkzeug.exceptions import UnsupportedMediaType
 
 from ..api import SWORDDeposit
 from .base import Packaging
+from invenio_sword.enum import ObjectTagKey
 from invenio_sword.typing import BytesReader
 
 __all__ = ["SimpleZipPackaging"]
@@ -15,6 +18,7 @@ __all__ = ["SimpleZipPackaging"]
 
 class SimpleZipPackaging(Packaging):
     content_type = "application/zip"
+    packaging_name = "http://purl.org/net/sword/3.0/package/SimpleZip"
 
     def ingest(
         self,
@@ -27,20 +31,50 @@ class SimpleZipPackaging(Packaging):
         if content_type != self.content_type:
             raise UnsupportedMediaType
 
+        original_deposit_filename = "original-deposit-{}.zip".format(uuid.uuid4())
+
         with tempfile.TemporaryFile() as f:
             shutil.copyfileobj(stream, f)
             f.seek(0)
 
-            zip = zipfile.ZipFile(f)
+            with zipfile.ZipFile(f) as zip:
+                names = set(zip.namelist())
 
-            names = set(zip.namelist())
+                for name in names:
+                    object_version = ObjectVersion.create(
+                        record.bucket,
+                        name,
+                        mimetype=mimetypes.guess_type(name)[0],
+                        stream=zip.open(name),
+                    )
+                    ObjectVersionTag.create(
+                        object_version=object_version,
+                        key=ObjectTagKey.FileSetFile.value,
+                        value="true",
+                    )
+                    ObjectVersionTag.create(
+                        object_version=object_version,
+                        key=ObjectTagKey.DerivedFrom.value,
+                        value=original_deposit_filename,
+                    )
 
-            for name in names:
-                ObjectVersion.create(
-                    record.bucket,
-                    name,
-                    mimetype=mimetypes.guess_type(name)[0],
-                    stream=zip.open(name),
-                )
+            f.seek(0)
 
-        return names
+            original_deposit = ObjectVersion.create(
+                record.bucket,
+                original_deposit_filename,
+                mimetype=self.content_type,
+                stream=f,
+            )
+            ObjectVersionTag.create(
+                object_version=original_deposit,
+                key=ObjectTagKey.OriginalDeposit.value,
+                value="true",
+            )
+            ObjectVersionTag.create(
+                object_version=original_deposit,
+                key=ObjectTagKey.Packaging.value,
+                value=self.packaging_name,
+            )
+
+        return names | {original_deposit_filename}

--- a/tests/fixtures/binary.svg
+++ b/tests/fixtures/binary.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg"
+ width="467" height="462">
+  <rect x="80" y="60" width="250" height="250" rx="20"
+      style="fill:#ff0000; stroke:#000000;stroke-width:2px;" />
+
+  <rect x="140" y="120" width="250" height="250" rx="40"
+      style="fill:#0000ff; stroke:#000000; stroke-width:2px;
+      fill-opacity:0.7;" />
+</svg>

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,137 @@
+import os
+import time
+from http import HTTPStatus
+
+import pytest
+from flask_security import url_for_security
+
+original_deposit = (
+    object()
+)  # A sentinel, representing the original deposit in our expected data
+
+packaged_content = {
+    "example.svg": {
+        "rels": [
+            "http://purl.org/net/sword/3.0/terms/derivedResource",
+            "http://purl.org/net/sword/3.0/terms/fileSetFile",
+        ],
+        "contentType": "image/svg+xml",
+        "status": "http://purl.org/net/sword/3.0/filestate/ingested",
+        "derivedFrom": original_deposit,
+    },
+    "hello.txt": {
+        "rels": [
+            "http://purl.org/net/sword/3.0/terms/derivedResource",
+            "http://purl.org/net/sword/3.0/terms/fileSetFile",
+        ],
+        "contentType": "text/plain",
+        "status": "http://purl.org/net/sword/3.0/filestate/ingested",
+        "derivedFrom": original_deposit,
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "filename,packaging,content_type,expected_links",
+    [
+        # A binary deposit
+        (
+            "binary.svg",
+            "http://purl.org/net/sword/3.0/package/Binary",
+            "image/svg+xml",
+            {
+                "binary.svg": {
+                    "rels": [
+                        "http://purl.org/net/sword/3.0/terms/fileSetFile",
+                        "http://purl.org/net/sword/3.0/terms/originalDeposit",
+                    ],
+                    "contentType": "image/svg+xml",
+                    "status": "http://purl.org/net/sword/3.0/filestate/ingested",
+                }
+            },
+        ),
+        # A simple zip deposit
+        (
+            "simple.zip",
+            "http://purl.org/net/sword/3.0/package/SimpleZip",
+            "application/zip",
+            {
+                original_deposit: {
+                    "rels": ["http://purl.org/net/sword/3.0/terms/originalDeposit"],
+                    "contentType": "application/zip",
+                    "status": "http://purl.org/net/sword/3.0/filestate/ingested",
+                    "packaging": "http://purl.org/net/sword/3.0/package/SimpleZip",
+                },
+                **packaged_content,  # type: ignore
+            },
+        ),
+        # A BagIt deposit
+        (
+            "bagit.zip",
+            "http://purl.org/net/sword/3.0/package/SWORDBagIt",
+            "application/zip",
+            {
+                original_deposit: {
+                    "rels": ["http://purl.org/net/sword/3.0/terms/originalDeposit"],
+                    "contentType": "application/zip",
+                    "status": "http://purl.org/net/sword/3.0/filestate/ingested",
+                    "packaging": "http://purl.org/net/sword/3.0/package/SWORDBagIt",
+                },
+                **packaged_content,  # type: ignore
+            },
+        ),
+    ],
+)
+def test_ingest(
+    api,
+    users,
+    location,
+    es,
+    fixtures_path,
+    filename,
+    packaging,
+    content_type,
+    expected_links,
+):
+    with api.test_request_context(), api.test_client() as client:
+        client.post(
+            url_for_security("login"),
+            data={"email": users[0]["email"], "password": "tester"},
+        )
+
+        with open(os.path.join(fixtures_path, filename), "rb") as f:
+            response = client.post(
+                "/sword/service-document",
+                data=f,
+                headers={
+                    "Packaging": packaging,
+                    "Content-Type": content_type,
+                    "Content-Disposition": "attachment; filename={}".format(filename),
+                },
+            )
+        assert response.status_code == HTTPStatus.CREATED
+
+        time.sleep(1)
+
+        response = client.get(response.headers["Location"])
+
+        for link in response.json["links"]:
+            print(link)
+            key = link["@id"].split("/", 7)[-1]
+            if (
+                "http://purl.org/net/sword/3.0/terms/originalDeposit" in link["rels"]
+                and "http://purl.org/net/sword/3.0/terms/fileSetFile"
+                not in link["rels"]
+            ):
+                expected_link = expected_links[original_deposit]
+            else:
+                expected_link = expected_links[key]
+
+            if "derivedFrom" in link:
+                link["derivedFrom"] = original_deposit
+
+            expected_link["@id"] = response.json["@id"] + "/file/" + key
+
+            assert expected_link == link
+
+        assert len(response.json["links"]) == len(expected_links)


### PR DESCRIPTION
The newly-maintained ObjectVersionTag data is used to populate `links` data in
the status document.