### PR TITLE
Rework metadata to put metadata in buckets

### DIFF
--- a/invenio_sword/api.py
+++ b/invenio_sword/api.py
@@ -158,10 +158,6 @@ class SWORDDeposit(Deposit):
     def original_deposit_key_prefix(self):
         return ".original-deposit-{}/".format(self.pid.pid_value)
 
-    @property
-    def sword_metadata(self):
-        raise NotImplementedError
-
     def set_metadata(
         self,
         source: typing.Optional[typing.Union[BytesReader, dict]],

--- a/invenio_sword/api.py
+++ b/invenio_sword/api.py
@@ -163,6 +163,7 @@ class SWORDDeposit(Deposit):
         source: typing.Optional[typing.Union[BytesReader, dict]],
         metadata_class: typing.Type[Metadata],
         content_type: str = None,
+        derived_from: str = None,
         replace: bool = True,
     ) -> typing.Optional[Metadata]:
         if isinstance(source, dict):
@@ -247,6 +248,12 @@ class SWORDDeposit(Deposit):
                 key=ObjectTagKey.MetadataFormat.value,
                 value=metadata_class.metadata_format,
             )
+            if derived_from:
+                ObjectVersionTag.create(
+                    object_version=object_version,
+                    key=ObjectTagKey.DerivedFrom.value,
+                    value=derived_from,
+                )
 
             return metadata
 

--- a/invenio_sword/enum.py
+++ b/invenio_sword/enum.py
@@ -6,3 +6,4 @@ class ObjectTagKey(enum.Enum):
     DerivedFrom = "invenio_sword.derivedFrom"
     FileSetFile = "invenio_sword.fileSetFile"
     Packaging = "invenio_sword.packaging"
+    MetadataFormat = "invenio_sword.metadataFormat"

--- a/invenio_sword/metadata/base.py
+++ b/invenio_sword/metadata/base.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import json
 import typing
+import uuid
 
-from invenio_sword.api import SWORDDeposit
-from invenio_sword.typing import BytesReader
+import rdflib
+from rdflib.namespace import DC
+
+from ..typing import BytesReader
+
+if typing.TYPE_CHECKING:  # pragma: nocover
+    from invenio_sword.api import SWORDDeposit
 
 
 class Metadata:
     content_type: str
+    filename: str
+    metadata_format: str
 
     @classmethod
     def from_document(
@@ -15,14 +24,38 @@ class Metadata:
     ) -> Metadata:
         raise NotImplementedError  # pragma: nocover
 
+    def to_sword_metadata(self) -> dict:
+        raise NotImplementedError  # pragma: nocover
+
     def update_record_metadata(self, record: SWORDDeposit):
+        graph = rdflib.Graph()
+        subject = rdflib.URIRef("urn:uuid:" + str(uuid.uuid4()))
+
+        data = {
+            **self.to_sword_metadata(),
+            "@id": str(subject),
+        }
+        graph.parse(data=json.dumps(data), format="json-ld")
+
+        predicates = set(graph.predicates(subject=subject))
+
+        if "metadata" not in record:
+            record["metadata"] = {}
+
+        if DC.title in predicates:
+            if "title_statement" not in record["metadata"]:
+                record["metadata"]["title_statement"] = {}
+            record["metadata"]["title_statement"]["title"] = str(
+                graph.value(subject, DC.title)
+            )
+        elif "title" in record["metadata"].get("title_statement", {}):
+            del record["metadata"]["title_statement"]["title"]
+
+    def __bytes__(self):
         raise NotImplementedError  # pragma: nocover
 
-    def to_json(self) -> typing.Dict[str, typing.Any]:
-        raise NotImplementedError  # pragma: nocover
-
-    def to_document(self, metadata_url):
-        raise NotImplementedError  # pragma: nocover
+    def __add__(self, other):
+        return NotImplemented  # pragma: nocover
 
 
 class JSONMetadata(Metadata):

--- a/invenio_sword/metadata/sword.py
+++ b/invenio_sword/metadata/sword.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 import json
 import typing
-import uuid
 
-import rdflib
-from rdflib.namespace import DC
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import UnsupportedMediaType
 
 from .base import JSONMetadata
-from invenio_sword.api import SWORDDeposit
 from invenio_sword.typing import BytesReader
 
 __all__ = ["SWORDMetadata"]
@@ -18,6 +14,8 @@ __all__ = ["SWORDMetadata"]
 
 class SWORDMetadata(JSONMetadata):
     content_type = "application/ld+json"
+    filename = "sword.jsonld"
+    metadata_format = "http://purl.org/net/sword/3.0/types/Metadata"
 
     def __init__(self, data):
         self.data = data
@@ -43,40 +41,14 @@ class SWORDMetadata(JSONMetadata):
         data.pop("@id", None)
         return cls(data)
 
-    def update_record_metadata(
-        self, record: SWORDDeposit,
-    ):
-        graph = rdflib.Graph()
-        subject = rdflib.URIRef("urn:uuid:" + str(uuid.uuid4()))
-
-        data = {
-            **self.data,
-            "@id": str(subject),
-        }
-        graph.parse(data=json.dumps(data), format="json-ld")
-
-        predicates = set(graph.predicates(subject=subject))
-
-        if "metadata" not in record:
-            record["metadata"] = {}
-
-        if DC.title in predicates:
-            if "title_statement" not in record["metadata"]:
-                record["metadata"]["title_statement"] = {}
-            record["metadata"]["title_statement"]["title"] = str(
-                graph.value(subject, DC.title)
-            )
-        elif "title" in record["metadata"].get("title_statement", {}):
-            del record["metadata"]["title_statement"]["title"]
-
-    def to_json(self):
+    def to_sword_metadata(self) -> dict:
         # Record the full SWORD metadata without the '@id' key
         return {k: self.data[k] for k in self.data if k != "@id"}
-
-    def to_document(self, metadata_url):
-        return json.dumps({**self.data, "@id": metadata_url}, indent=2)
 
     def __add__(self, other):
         if not isinstance(other, SWORDMetadata):
             return NotImplemented
         return type(self)({**self.data, **other.data})
+
+    def __bytes__(self):
+        return json.dumps(self.data, indent=2).encode("utf-8")

--- a/invenio_sword/packaging/__init__.py
+++ b/invenio_sword/packaging/__init__.py
@@ -1,5 +1,13 @@
 from .bagit import SWORDBagItPackaging
+from .base import IngestResult
+from .base import Packaging
 from .binary import BinaryPackaging
 from .zip import SimpleZipPackaging
 
-__all__ = ["SWORDBagItPackaging", "BinaryPackaging", "SimpleZipPackaging"]
+__all__ = [
+    "BinaryPackaging",
+    "IngestResult",
+    "Packaging",
+    "SWORDBagItPackaging",
+    "SimpleZipPackaging",
+]

--- a/invenio_sword/packaging/bagit.py
+++ b/invenio_sword/packaging/bagit.py
@@ -97,6 +97,7 @@ class SWORDBagItPackaging(Packaging):
                             metadata_f,
                             metadata_class=SWORDMetadata,
                             content_type="application/ld+json",
+                            derived_from=original_deposit_filename,
                             replace=True,
                         )
 

--- a/invenio_sword/packaging/bagit.py
+++ b/invenio_sword/packaging/bagit.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import mimetypes
 import os
 import shutil
 import tempfile
+import typing
 import uuid
 import zipfile
 
@@ -12,12 +15,14 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import NotImplemented
 from werkzeug.exceptions import UnsupportedMediaType
 
+from ..enum import ObjectTagKey
+from ..metadata import SWORDMetadata
+from ..typing import BytesReader
 from .base import IngestResult
 from .base import Packaging
-from invenio_sword.api import SWORDDeposit
-from invenio_sword.enum import ObjectTagKey
-from invenio_sword.metadata import SWORDMetadata
-from invenio_sword.typing import BytesReader
+
+if typing.TYPE_CHECKING:  # pragma: nocover
+    from invenio_sword.api import SWORDDeposit
 
 __all__ = ["SWORDBagItPackaging"]
 
@@ -84,8 +89,11 @@ class SWORDBagItPackaging(Packaging):
                     and "metadata/sword.json" in bag.entries
                 ):
                     with open(metadata_path, "rb") as metadata_f:
-                        record.sword_metadata = SWORDMetadata.from_document(
-                            metadata_f, content_type=SWORDMetadata.content_type,
+                        record.set_metadata(
+                            metadata_f,
+                            metadata_class=SWORDMetadata,
+                            content_type="application/ld+json",
+                            replace=True,
                         )
 
                 # Ingest payload files

--- a/invenio_sword/packaging/bagit.py
+++ b/invenio_sword/packaging/bagit.py
@@ -42,7 +42,11 @@ class SWORDBagItPackaging(Packaging):
         if content_type != self.content_type:
             raise UnsupportedMediaType
 
-        original_deposit_filename = "original-deposit-{}.zip".format(uuid.uuid4())
+        original_deposit_filename = (
+            record.original_deposit_key_prefix
+            + "sword-bagit-{}.zip".format(uuid.uuid4())
+        )
+
         unpackaged_objects = []
 
         with tempfile.TemporaryDirectory() as path:

--- a/invenio_sword/packaging/base.py
+++ b/invenio_sword/packaging/base.py
@@ -6,7 +6,7 @@ from invenio_files_rest.models import ObjectVersion
 
 from ..typing import BytesReader
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: nocover
     from ..api import SWORDDeposit
 
 

--- a/invenio_sword/packaging/base.py
+++ b/invenio_sword/packaging/base.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Iterable
-from typing import Optional
+import typing
 
 from invenio_files_rest.models import ObjectVersion
 
-from invenio_sword.api import SWORDDeposit
-from invenio_sword.typing import BytesReader
+from ..typing import BytesReader
+
+if typing.TYPE_CHECKING:
+    from ..api import SWORDDeposit
 
 
 class Packaging:
@@ -26,8 +27,8 @@ class Packaging:
 class IngestResult:
     def __init__(
         self,
-        original_deposit: Optional[ObjectVersion],
-        unpackaged_objects: Iterable[ObjectVersion] = None,
+        original_deposit: typing.Optional[ObjectVersion],
+        unpackaged_objects: typing.Iterable[ObjectVersion] = None,
     ):
         self.original_deposit = original_deposit
         self.ingested_objects = list(unpackaged_objects or ())

--- a/invenio_sword/packaging/binary.py
+++ b/invenio_sword/packaging/binary.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import mimetypes
+import typing
 
 from invenio_files_rest.models import ObjectVersion
 from invenio_files_rest.models import ObjectVersionTag
 
-from ..api import SWORDDeposit
+from ..enum import ObjectTagKey
+from ..typing import BytesReader
 from .base import IngestResult
 from .base import Packaging
-from invenio_sword.enum import ObjectTagKey
-from invenio_sword.typing import BytesReader
+
+if typing.TYPE_CHECKING:  # pragma: nocover
+    from ..api import SWORDDeposit
 
 __all__ = ["BinaryPackaging"]
 

--- a/invenio_sword/packaging/zip.py
+++ b/invenio_sword/packaging/zip.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import mimetypes
 import shutil
 import tempfile
+import typing
 import uuid
 import zipfile
 
@@ -8,11 +11,13 @@ from invenio_files_rest.models import ObjectVersion
 from invenio_files_rest.models import ObjectVersionTag
 from werkzeug.exceptions import UnsupportedMediaType
 
-from ..api import SWORDDeposit
+from ..enum import ObjectTagKey
+from ..typing import BytesReader
 from .base import IngestResult
 from .base import Packaging
-from invenio_sword.enum import ObjectTagKey
-from invenio_sword.typing import BytesReader
+
+if typing.TYPE_CHECKING:
+    from ..api import SWORDDeposit
 
 __all__ = ["SimpleZipPackaging"]
 

--- a/invenio_sword/packaging/zip.py
+++ b/invenio_sword/packaging/zip.py
@@ -16,7 +16,7 @@ from ..typing import BytesReader
 from .base import IngestResult
 from .base import Packaging
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: nocover
     from ..api import SWORDDeposit
 
 __all__ = ["SimpleZipPackaging"]

--- a/invenio_sword/packaging/zip.py
+++ b/invenio_sword/packaging/zip.py
@@ -37,7 +37,10 @@ class SimpleZipPackaging(Packaging):
         if content_type != self.content_type:
             raise UnsupportedMediaType
 
-        original_deposit_filename = "original-deposit-{}.zip".format(uuid.uuid4())
+        original_deposit_filename = (
+            record.original_deposit_key_prefix
+            + "simple-zip-{}.zip".format(uuid.uuid4())
+        )
         unpackaged_objects = []
 
         with tempfile.TemporaryFile() as f:

--- a/invenio_sword/views.py
+++ b/invenio_sword/views.py
@@ -99,7 +99,7 @@ class SWORDDepositView(ContentNegotiatedMethodView):
                     request.json["metadata"], self.metadata_class, replace=replace,
                 )
             else:
-                record.set_metadata(
+                result = record.set_metadata(
                     request.stream,
                     self.metadata_class,
                     request.content_type,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,11 @@ def test_metadata_format():
 
 
 class TestMetadata(Metadata):
+    name = "test"
+    content_type = "application/binary"
+    metadata_format = "http://example.org/TestMetadataFormat"
+    filename = "test.bin"
+
     def __init__(self, data):
         self.data = data
 
@@ -111,7 +116,10 @@ class TestMetadata(Metadata):
     def from_document(
         cls, document: BytesReader, content_type: str, encoding: str = "utf_8"
     ) -> Metadata:
-        return cls({"data": document.read().decode()})
+        return cls(document.read())
+
+    def __bytes__(self):
+        return self.data
 
 
 @pytest.yield_fixture()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,7 +100,7 @@ def test_metadata_deposit(api, users, location, metadata_document):
                 "dc:title": "The title",
                 "dcterms:abstract": "This is my abstract",
             },
-            "swordMetadataFormat": "http://purl.org/net/sword/3.0/types/Metadata",
+            "swordMetadataSourceFormat": "http://purl.org/net/sword/3.0/types/Metadata",
             "$schema": "http://localhost/schemas/deposits/deposit-v1.0.0.json",
             "_deposit": {
                 "id": pid_value,

--- a/tests/test_bagit.py
+++ b/tests/test_bagit.py
@@ -85,7 +85,7 @@ def test_post_service_document_with_bagit_bag(api, users, location, fixtures_pat
                 "dc:title": "The title",
                 "dcterms:abstract": "This is my abstract",
             },
-            "swordMetadataFormat": "http://purl.org/net/sword/3.0/types/Metadata",
+            "swordMetadataSourceFormat": "http://purl.org/net/sword/3.0/types/Metadata",
         }
 
 

--- a/tests/test_fileset_view.py
+++ b/tests/test_fileset_view.py
@@ -5,8 +5,10 @@ from flask import url_for
 from flask_security import url_for_security
 from invenio_db import db
 from invenio_files_rest.models import ObjectVersion
+from invenio_files_rest.models import ObjectVersionTag
 
 from invenio_sword.api import SWORDDeposit
+from invenio_sword.enum import ObjectTagKey
 
 
 def test_get_fileset_url(api, users, location, es):
@@ -33,11 +35,16 @@ def test_put_fileset_url(api, users, location, es):
         )
         record = SWORDDeposit.create({})
         record.commit()
-        ObjectVersion.create(
+        object_version = ObjectVersion.create(
             record.bucket,
             key="old-file.txt",
             stream=io.BytesIO(b"hello"),
             mimetype="text/plain",
+        )
+        ObjectVersionTag.create(
+            object_version=object_version,
+            key=ObjectTagKey.FileSetFile.value,
+            value="true",
         )
         db.session.commit()
 

--- a/tests/test_fileset_view.py
+++ b/tests/test_fileset_view.py
@@ -1,4 +1,6 @@
 import io
+import json
+import os
 from http import HTTPStatus
 
 from flask import url_for
@@ -6,9 +8,12 @@ from flask_security import url_for_security
 from invenio_db import db
 from invenio_files_rest.models import ObjectVersion
 from invenio_files_rest.models import ObjectVersionTag
+from sqlalchemy import null
+from sqlalchemy import true
 
 from invenio_sword.api import SWORDDeposit
 from invenio_sword.enum import ObjectTagKey
+from invenio_sword.packaging import SWORDBagItPackaging
 
 
 def test_get_fileset_url(api, users, location, es):
@@ -116,3 +121,65 @@ def test_post_fileset_url(api, users, location, es):
             bucket=record.bucket, key="new-file.txt"
         ).one()
         assert new_object_version.is_head
+
+
+def test_delete_fileset(api, users, location, es, fixtures_path, test_metadata_format):
+    with api.test_request_context(), api.test_client() as client:
+        client.post(
+            url_for_security("login"),
+            data={"email": users[0]["email"], "password": "tester"},
+        )
+
+        # Create a deposit, initially with a metadata deposit
+        original_response = client.post(
+            url_for("invenio_sword.depid_service_document"),
+            data=json.dumps(
+                {
+                    "@context": "https://swordapp.github.io/swordv3/swordv3.jsonld",
+                    "title": "A title",
+                }
+            ),
+            headers={"Content-Disposition": "attachment; metadata=true",},
+        )
+
+        assert ObjectVersion.query.count() == 1
+
+        # Add some extra metadata
+        response = client.post(
+            original_response.json["metadata"]["@id"],
+            data=b"some metadata",
+            headers={"Metadata-Format": test_metadata_format},
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+        assert ObjectVersion.query.count() == 2
+
+        with open(os.path.join(fixtures_path, "bagit.zip"), "rb") as f:
+            response = client.post(
+                original_response.headers["Location"],
+                data=f,
+                headers={
+                    "Packaging": SWORDBagItPackaging.packaging_name,
+                    "Content-Type": "application/zip",
+                },
+            )
+            assert response.status_code == HTTPStatus.CREATED
+
+        # One test metadata, one old SWORD metadata, one new SWORD metadata, one original deposit, and two files
+        assert ObjectVersion.query.count() == 6
+        # One test metadata, one new SWORD metadata, one original deposit, and two files
+        assert ObjectVersion.query.filter(ObjectVersion.is_head == true()).count() == 5
+
+        # Now let's delete the fileset. This should ensure that there is only one extant file, as the SWORD metadata and
+        # original deposit were deposited as part of a fileset, leaving only the test dataset
+        response = client.delete(original_response.json["fileSet"]["@id"])
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+        # All four previously extent files now have file_id=NULL versions
+        assert ObjectVersion.query.count() == 10
+        assert (
+            ObjectVersion.query.filter(
+                ObjectVersion.is_head == true(), ObjectVersion.file_id != null()
+            ).count()
+            == 1
+        )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -180,9 +180,16 @@ def test_create_with_metadata_and_then_ingest(
 
         response = client.get(response.headers["Location"])
 
+        metadata_link_count = 0
+
         for link in response.json["links"]:
-            print(link)
             key = link["@id"].split("/", 7)[-1]
+
+            # Ignore ingested metadata files
+            if key.startswith(".metadata-"):
+                metadata_link_count += 1
+                continue
+
             if (
                 "http://purl.org/net/sword/3.0/terms/originalDeposit" in link["rel"]
                 and "http://purl.org/net/sword/3.0/terms/fileSetFile" not in link["rel"]
@@ -198,4 +205,4 @@ def test_create_with_metadata_and_then_ingest(
 
             assert expected_link == link
 
-        assert len(response.json["links"]) == len(expected_links)
+        assert len(response.json["links"]) == len(expected_links) + metadata_link_count

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -115,9 +115,14 @@ def test_ingest(
 
         response = client.get(response.headers["Location"])
 
+        metadata_file_count = 0
+
         for link in response.json["links"]:
-            print(link)
             key = link["@id"].split("/", 7)[-1]
+            if key.startswith(".metadata-"):
+                metadata_file_count += 1
+                continue
+
             if (
                 "http://purl.org/net/sword/3.0/terms/originalDeposit" in link["rel"]
                 and "http://purl.org/net/sword/3.0/terms/fileSetFile" not in link["rel"]
@@ -133,7 +138,7 @@ def test_ingest(
 
             assert expected_link == link
 
-        assert len(response.json["links"]) == len(expected_links)
+        assert len(response.json["links"]) == len(expected_links) + metadata_file_count
 
 
 @pytest.mark.parametrize(

--- a/tests/test_status_view.py
+++ b/tests/test_status_view.py
@@ -4,8 +4,10 @@ from http import HTTPStatus
 from flask_security import url_for_security
 from invenio_db import db
 from invenio_files_rest.models import ObjectVersion
+from invenio_files_rest.models import ObjectVersionTag
 
 from invenio_sword.api import SWORDDeposit
+from invenio_sword.enum import ObjectTagKey
 
 
 def test_get_status_document_not_found(api, location, es):
@@ -47,11 +49,16 @@ def test_put_status_document(api, users, location, es):
         record.commit()
         db.session.commit()
 
-        ObjectVersion.create(
+        object_version = ObjectVersion.create(
             record.bucket,
             "file.n3",
             mimetype="text/n3",
             stream=io.BytesIO(b"1 _:a 2 ."),
+        )
+        ObjectVersionTag.create(
+            object_version=object_version,
+            key=ObjectTagKey.FileSetFile.value,
+            value="true",
         )
 
         response = client.put(

--- a/tests/test_sword_metadata.py
+++ b/tests/test_sword_metadata.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from werkzeug.exceptions import UnsupportedMediaType
 
@@ -33,9 +35,8 @@ def test_update_record(metadata_document):
     assert record["metadata"]["title_statement"]["title"] == "The title"
 
 
-def test_metadata_to_json(metadata_document):
+def test_metadata_bytes_roundtrip(metadata_document):
     sword_metadata = SWORDMetadata.from_document(
         metadata_document, content_type="application/ld+json"
     )
-    data = sword_metadata.to_json()
-    assert data == sword_metadata.data
+    assert json.loads(bytes(sword_metadata)) == sword_metadata.data


### PR DESCRIPTION
This allows a user to upload metadata in multiple formats, and to have those
files appear in the status doc links.

An attempt is made to extract SWORD metadata from each format, and this is
stored on the record (with the SWORD metadata format metadata used for
preference).