### PR TITLE
Pin werkzeug at <1.0, due to flask-oauthlib incompatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_install:
 
 install:
   - pip install tox-travis pre-commit pytest pytest-cov codecov sphinx
-  - pip install elasticsearch invenio-access invenio-search flask-oauthlib elasticsearch-dsl invenio-app
+  - pip install elasticsearch invenio-access invenio-search flask-oauthlib elasticsearch-dsl invenio-app 'werkzeug<1.0'
   - pip install -e 'git+https://github.com/swordapp/sword3-common.py.git#egg=sword3common'
   - pip install -e .[$EXTRAS]
 


### PR DESCRIPTION
See https://github.com/inveniosoftware/invenio-oauth2server/issues/195 for more
information.