### PR TITLE
Type annotation, import, and pre-commit fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
       - id: check-toml
-      - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.750'
+    rev: 'v0.800'
     hooks:
     - id: mypy
       args: [--no-strict-optional, --ignore-missing-imports]

--- a/invenio_sword/packaging/base.py
+++ b/invenio_sword/packaging/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import mimetypes
 import typing
 import uuid
+from typing import Any
 from typing import Collection
 from typing import Union
 
@@ -38,7 +39,7 @@ class Packaging:
 
     def shortcut_unpack(
         self, object_version: ObjectVersion
-    ) -> Union[NotImplemented, Collection[str]]:
+    ) -> Union[Any, Collection[str]]:
         """Override this to shortcut task-based unpacking"""
         return NotImplemented
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ from time import sleep
 
 import pytest
 from celery.canvas import Signature
-from celery.task import Task
+from celery import Task
 from elasticsearch.exceptions import RequestError
 from flask import Flask
 from flask_babelex import Babel
@@ -44,6 +44,8 @@ from flask_breadcrumbs import Breadcrumbs
 from flask_celeryext import FlaskCeleryExt
 from flask_oauthlib.provider import OAuth2Provider
 from flask_security import login_user
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
 from helpers import fill_oauth2_headers
 from helpers import make_pdf_fixture
 from invenio_access import InvenioAccess
@@ -89,7 +91,6 @@ from sqlalchemy import inspect
 from sqlalchemy_utils.functions import create_database
 from sqlalchemy_utils.functions import database_exists
 from sqlalchemy_utils.functions import drop_database
-from werkzeug.wsgi import DispatcherMiddleware
 
 from invenio_sword import InvenioSword
 from invenio_sword.metadata import Metadata


### PR DESCRIPTION
These are all together because pre-commit won't pass any other way.

We update to the latest pre-commit hook versions, and drop the
now-obsolete flake8 hook.

We replace NotImplemented with Any, for simplicity, as mypy doesn't yet
handle this singleton very well
(https://github.com/python/mypy/issues/4791).

A few import locations have changed in our dependencies, so we now use
the new locations.