### PR TITLE
No longer pass encoding to json.load, as it's not acceptable in Py3.9

### DIFF
--- a/invenio_sword/metadata/sword.py
+++ b/invenio_sword/metadata/sword.py
@@ -33,8 +33,10 @@ class SWORDMetadata(JSONMetadata):
                 "Content-Type must be {}".format(cls.content_type)
             )
         if isinstance(document, BytesReader):
+            if encoding not in ('U8', 'UTF', 'utf8', 'utf_8', 'utf-8', 'cp65001'):
+                raise ValueError("encoding must be utf_8 or an alias thereof")
             try:
-                data = json.load(document, encoding=encoding)
+                data = json.load(document)
             except json.JSONDecodeError as e:
                 raise ContentMalformed("Unable to parse JSON") from e
         else:


### PR DESCRIPTION
json.load has ignored the encoding parameter since Python 3.1 as all
JSON documents are required to be UTF-8-encoded anyway. This parameter
has now finally been removed.

We now have a check to ensure that the client isn't claiming to be
sending JSON as a non-UTF-8 encoding.

For more details, see <https://bugs.python.org/issue39377>.